### PR TITLE
Fix programmatically changing index

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -723,6 +723,26 @@ class _UserProfileState extends State<UserProfile> {
                   NavbarNotifier.popRoute(1);
                 },
                 child: const Text('Pop Product Route')),
+            const SizedBox(
+              height: 24,
+            ),
+            const Text("Change tab programmatically:"),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                    onPressed: () {
+                      NavbarNotifier.index = 0;
+                    },
+                    child: const Text("Go to tab 1")),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                    onPressed: () {
+                      NavbarNotifier.index = 1;
+                    },
+                    child: const Text("Go to tab 2")),
+              ],
+            )
           ],
         ),
       ),

--- a/lib/src/navbar_router.dart
+++ b/lib/src/navbar_router.dart
@@ -49,7 +49,6 @@ class DestinationRouter {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-
     return other is DestinationRouter &&
         listEquals(other.destinations, destinations) &&
         other.initialRoute == initialRoute &&
@@ -215,7 +214,11 @@ class _NavbarRouterState extends State<NavbarRouter>
     // re-enable the initial badge that was hidden on setting NavbarNotifier.index
     NavbarNotifier.makeBadgeVisible(NavbarNotifier.currentIndex, true);
     initAnimation();
+
     NavbarNotifier.index = widget.initialIndex;
+    NavbarNotifier.addIndexChangeListener((i) {
+      _changeTab(i);
+    });
   }
 
   void updateWidget() {
@@ -388,10 +391,6 @@ class _NavbarRouterState extends State<NavbarRouter>
                             }
                           } else {
                             NavbarNotifier.index = x;
-                            if (widget.onChanged != null) {
-                              widget.onChanged!(x);
-                            }
-                            _handleFadeAnimation();
                           }
                         },
                         menuItems: items),
@@ -399,6 +398,16 @@ class _NavbarRouterState extends State<NavbarRouter>
                 ],
               );
             }));
+  }
+
+  _changeTab(int x) {
+    final currentIndex = fadeAnimation.indexWhere((e) => !e.isDismissed);
+    if (currentIndex != x) {
+      if (widget.onChanged != null) {
+        widget.onChanged!(x);
+      }
+      _handleFadeAnimation();
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue with changing `NavbarNotifier.index`. The current code base doesn't start animation to change a visible route, it happens only when user taps on a tab. These changes run "changing tab" animation with corresponding `onChanged` listener for all cases (independently, if it was called programmatically or not).

https://github.com/maheshj01/navbar_router/issues/57


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshmnj

<!-- Links -->
[Contributor Guide]: https://github.com/maheshmnj/searchfield/blob/master/CONTRIBUTING.md